### PR TITLE
second argument for getException should be passed in seconds (not milliseconds)

### DIFF
--- a/date.js
+++ b/date.js
@@ -1,5 +1,6 @@
 var mDate = {
-	startOnMonday:true,
+	//true is the default setting for startOnMonday in dhtmlx sheduler .
+    startOnMonday:true,
 	toFixed:function(num){
 		if (num<10)	return "0"+num;
 		return num;

--- a/date.js
+++ b/date.js
@@ -1,5 +1,5 @@
 var mDate = {
-	startOnMonday:false,
+	startOnMonday:true,
 	toFixed:function(num){
 		if (num<10)	return "0"+num;
 		return num;

--- a/index.js
+++ b/index.js
@@ -23,9 +23,9 @@ function getEvents(data, from, to){
 	//process events
 	for (var i=0; i<data.length; i++){
 		var ev = data[i];
-        //events with rec_type none are deleted occurances from recurring events and should be ignored
+        //events with rec_type none are deleted occurences from recurring events and should be ignored
 		if (ev.rec_type === "none") continue;
-        //event with a non empty rec_type are recurring events and should be processed
+        //events with a non empty rec_type are recurring events and should be processed
 		if (ev.rec_type)
 			processRecurringEvent(ev, exceptions, events, from, to);
         //single events and exceptions are pushed to the events array directly

--- a/index.js
+++ b/index.js
@@ -23,12 +23,12 @@ function getEvents(data, from, to){
 	//process events
 	for (var i=0; i<data.length; i++){
 		var ev = data[i];
-        //events with rec_type none are deleted occurences from recurring events and should be ignored
+        //events with rec_type none are deleted occurrences of recurring events and should be ignored
 		if (ev.rec_type === "none") continue;
         //events with a non empty rec_type are recurring events and should be processed
 		if (ev.rec_type)
 			processRecurringEvent(ev, exceptions, events, from, to);
-        //single events and exceptions are pushed to the events array directly
+        //one time only events and exceptions are pushed to the events array directly
 		else
 			if ((!from || ev.end_date>from) && (!to || ev.start_date < to))
 				events.push(ev);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scheduler-helper",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Operations with recurring events for DHTMLX Scheduler and Webix Scheduler",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The call to getException on line 63 currently receives a second argument in milliseconds.

However getException expects a value in seconds because the key parameter is ultimately tested against event_length which is denominated in seconds. If you pass in milliseconds, getException wil always return false and no overlaps of recurrent events and their exceptions will be filtered out.

Fixed by dividing the second argument of the getException call by 1000